### PR TITLE
Bump: moesif-aws-lambda-go version to 1.0.2

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -16,12 +16,12 @@
   version = "v1.13.3"
 
 [[projects]]
-  digest = "1:7d75978be853c0f9b1e1a640e6fb3e96011f3a756db552baef1534de4b50c61e"
+  digest = "1:e6fba57b8b51ec35dea0f54bd17a76bdb1df23be3fbec1d1acc6fd0aa1823c1d"
   name = "github.com/moesif/moesif-aws-lambda-go"
   packages = ["."]
   pruneopts = "UT"
-  revision = "a80ba7eb1ebd7fedd94b8147d675305f106fe623"
-  version = "v1.0.1"
+  revision = "d0e9d2b9c0018dd97cd04d249739401ff7fed8fd"
+  version = "v1.0.2"
 
 [[projects]]
   digest = "1:9f870f2e8d1ed5690703df16c9608516dba226ecb5c808d58a0db46a6a7b5059"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,7 +31,7 @@
 
 [[constraint]]
   name = "github.com/moesif/moesif-aws-lambda-go"
-  version = "1.0.1"
+  version = "1.0.2"
 
 [[constraint]]
   name = "github.com/moesif/moesifapi-go"

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.12
 
 require (
 	github.com/aws/aws-lambda-go v1.13.3
-	github.com/moesif/moesif-aws-lambda-go v1.0.1
+	github.com/moesif/moesif-aws-lambda-go v1.0.2
 	github.com/moesif/moesifapi-go v1.0.3
 )

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQ
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/moesif/moesif-aws-lambda-go v1.0.1 h1:rnGtkYIk6vEcg/LfHYj9YRTdXgDwh9I/9QjKIw9zs/A=
-github.com/moesif/moesif-aws-lambda-go v1.0.1/go.mod h1:/Tg52R5BQXlhPvGeQRsy1dGFTpki9WiEHCJrL6GsXpA=
+github.com/moesif/moesif-aws-lambda-go v1.0.2 h1:JVb7cWG+IPxeoV4E2KRFc7l2Vb7my0TcQgJocVGnWyg=
+github.com/moesif/moesif-aws-lambda-go v1.0.2/go.mod h1:/Tg52R5BQXlhPvGeQRsy1dGFTpki9WiEHCJrL6GsXpA=
 github.com/moesif/moesifapi-go v1.0.3 h1:+f5aacrxbTgCrhC54sdvWmEfwJM3DJJO7qOz23vXSyI=
 github.com/moesif/moesifapi-go v1.0.3/go.mod h1:y6lla+hr7apWO+cxOmcycZQ3cZHNgfu8mIwViNxifxo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
Bump: moesif-aws-lambda-go version to 1.0.2